### PR TITLE
Enable JPMS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,9 +12,12 @@ version = '0.0.1-SNAPSHOT'
 description = 'sc cli - simple ai for everyday people'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(22)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(22)
+    }
+    modularity {
+        inferModulePath = true
+    }
 }
 
 repositories {

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,24 @@
+open module org.sc.ai.cli {
+    requires spring.boot;
+    requires spring.boot.autoconfigure;
+    requires spring.context;
+    requires spring.beans;
+    requires spring.core;
+    requires org.slf4j;
+    requires org.jline;
+    requires info.picocli;
+    requires org.yaml.snakeyaml;
+    requires reactor.core;
+    requires jakarta.annotation;
+    // Spring AI modules
+    requires spring.ai.starter.model.ollama;
+    requires spring.ai.starter.model.chat.memory.repository.jdbc;
+    requires spring.ai.pdf.document.reader;
+    requires spring.ai.markdown.document.reader;
+    requires spring.ai.jsoup.document.reader;
+    exports org.sc.ai.cli;
+    exports org.sc.ai.cli.chat;
+    exports org.sc.ai.cli.config;
+    exports org.sc.ai.cli.rag;
+    exports org.sc.ai.cli.command;
+}


### PR DESCRIPTION
## Summary
- create `module-info.java` to define `org.sc.ai.cli` module
- enable Gradle Java modularity for JPMS

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_687235878d0c83359c740be15267584a