### PR TITLE
Support cancelling streamed chat output with Ctrl+C

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -58,6 +58,7 @@ sc chat
 sc> Hello, how are you?
 Hello! I'm functioning as intended, thank you. How can I assist you today?
 ```
+Press `Ctrl+C` during a streamed response to cancel generation and return to the prompt.
 
 ## `config`
 

--- a/src/main/java/org/sc/ai/cli/CliConfiguration.java
+++ b/src/main/java/org/sc/ai/cli/CliConfiguration.java
@@ -15,6 +15,7 @@ import org.jline.reader.impl.DefaultParser;
 import org.jline.terminal.Terminal;
 import org.jline.terminal.TerminalBuilder;
 import org.sc.ai.cli.chat.ChatSubCommand;
+import org.sc.ai.cli.chat.StreamingContext;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -43,13 +44,14 @@ public class CliConfiguration {
      * @throws IOException if an I/O error occurs
      */
     @Bean
-    Terminal terminal(@Value("${spring.application.name}") String name) throws IOException {
+    Terminal terminal(@Value("${spring.application.name}") String name, StreamingContext streamingContext) throws IOException {
         var terminal = TerminalBuilder.builder()
                 .name(name)
                 .system(true)
                 .build();
         terminal.handle(Terminal.Signal.INT, signal -> {
-            terminal.writer().println("Received SIG" + signal + " (CTR+C)");
+            streamingContext.cancel();
+            terminal.writer().println("Generation cancelled.");
             terminal.flush();
         });
         terminal.handle(Terminal.Signal.TSTP, signal -> {

--- a/src/main/java/org/sc/ai/cli/chat/StreamingContext.java
+++ b/src/main/java/org/sc/ai/cli/chat/StreamingContext.java
@@ -1,0 +1,38 @@
+package org.sc.ai.cli.chat;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.springframework.stereotype.Component;
+
+import reactor.core.Disposable;
+
+/**
+ * Tracks the current streaming subscription so it can be cancelled from signal handlers.
+ */
+@Component
+public class StreamingContext {
+    private final AtomicReference<Disposable> subscription = new AtomicReference<>();
+    private final AtomicReference<CountDownLatch> latchRef = new AtomicReference<>();
+
+    public void register(Disposable disposable, CountDownLatch latch) {
+        subscription.set(disposable);
+        latchRef.set(latch);
+    }
+
+    public void clear() {
+        subscription.set(null);
+        latchRef.set(null);
+    }
+
+    public void cancel() {
+        Disposable d = subscription.getAndSet(null);
+        CountDownLatch latch = latchRef.getAndSet(null);
+        if (d != null && !d.isDisposed()) {
+            d.dispose();
+        }
+        if (latch != null) {
+            latch.countDown();
+        }
+    }
+}

--- a/src/test/java/org/sc/ai/cli/chat/ChatCommandTest.java
+++ b/src/test/java/org/sc/ai/cli/chat/ChatCommandTest.java
@@ -34,6 +34,7 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.sc.ai.cli.CliConfiguration;
 import org.springframework.ai.model.ollama.autoconfigure.OllamaChatProperties;
+import org.sc.ai.cli.chat.StreamingContext;
 
 import picocli.CommandLine;
 import picocli.shell.jline3.PicocliCommands;
@@ -52,6 +53,7 @@ class ChatCommandTest {
 
     private StringWriter sw;
     private CommandLine cmd;
+    private StreamingContext streamingContext;
 
     private CommandRegistry picocliCommands(Terminal terminal) {
         var chatSubCommand = new ChatSubCommand(terminal);
@@ -70,7 +72,8 @@ class ChatCommandTest {
         SystemRegistry systemRegistry = new SystemRegistryImpl(new DefaultParser().regexCommand(CliConfiguration.REGEX_COMMAND), terminal, workDir, null);
         systemRegistry.setCommandRegistries(picocliCommands);
         systemRegistry.register("/?", picocliCommands);
-        ChatCommand chatCommand = new ChatCommand(chatService, lineReader, ollamaChatProperties, systemRegistry);
+        streamingContext = new StreamingContext();
+        ChatCommand chatCommand = new ChatCommand(chatService, lineReader, ollamaChatProperties, systemRegistry, streamingContext);
         cmd = new CommandLine(chatCommand);
         cmd.setOut(pw);
         cmd.setErr(pw);
@@ -160,5 +163,23 @@ class ChatCommandTest {
         // Then
         assertThat(exitCode).isZero();
         verify(lineReader).readLine("sc> ");
+    }
+
+    @Test
+    void shouldCancelStreaming_whenInterrupted() throws Exception {
+        when(ollamaChatProperties.getModel()).thenReturn("llama2");
+        Flux<String> flux = Flux.interval(java.time.Duration.ofMillis(50))
+                .map(i -> "chunk" + i)
+                .take(5);
+        when(chatService.sendAndStreamMessage(any(), any(), any())).thenReturn(flux);
+
+        Thread t = new Thread(() -> cmd.execute("hello"));
+        t.start();
+        Thread.sleep(80); // wait for a couple chunks
+        streamingContext.cancel();
+        t.join(1000);
+
+        assertThat(sw.toString()).startsWith("chunk0");
+        assertThat(sw.toString()).doesNotContain("chunk4");
     }
 }


### PR DESCRIPTION
## Summary
- add `StreamingContext` component to track active subscriptions
- inject `StreamingContext` into `ChatCommand` and `CliConfiguration`
- handle `Ctrl+C` in the terminal to cancel streaming
- block on a latch in `ChatCommand` so streaming can be disposed
- document cancellation in the README
- test the cancellation path

## Testing
- `./gradlew test --no-daemon` *(fails: unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_6869c9a8fbd88335b7c917a502194973