### PR TITLE
Fix provider options parsing and improve tests

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -167,7 +167,7 @@ The following document formats are supported:
 ```bash
 # Load a PDF document from the local filesystem and write the response to a file
 sc rag --etl=file --output output.txt file:///path/to/document.pdf
-# Load a HTM document from a remote URL and write the response to a file
+# Load a HTML document from a remote URL and write the response to a file
 sc rag --etl=file --output output.txt https://docs.spring.io/spring-ai/reference/api/etl-pipeline.html
 # Load a plain text document from a local file and write the response to a file
 sc rag --etl=file --output output.txt file:///path/to/plain.txt

--- a/src/main/java/org/sc/ai/cli/config/ConfigService.java
+++ b/src/main/java/org/sc/ai/cli/config/ConfigService.java
@@ -78,15 +78,12 @@ public class ConfigService {
                         baseUrl = URI.create(element.getValue().toString());
                     } else if ("model".equals(element.getKey())) {
                         model = element.getValue().toString();
-                    } else if ("options".equals(element.getKey())) {
-                        Object val = element.getValue();
-                        if (val instanceof Map<?, ?> optMap) {
-                            for (var optEntry : optMap.entrySet()) {
-                                var optKey = optEntry.getKey();
-                                var optVal = optEntry.getValue();
-                                if (optKey != null && optVal != null) {
-                                    options.put(optKey.toString(), optVal.toString());
-                                }
+                    } else if ("options".equals(element.getKey()) && element.getValue() instanceof Map<?, ?> optMap) {
+                        for (var optEntry : optMap.entrySet()) {
+                            var optKey = optEntry.getKey();
+                            var optVal = optEntry.getValue();
+                            if (optKey != null && optVal != null) {
+                                options.put(optKey.toString(), optVal.toString());
                             }
                         }
                     }

--- a/src/test/java/org/sc/ai/cli/chat/ChatCommandTest.java
+++ b/src/test/java/org/sc/ai/cli/chat/ChatCommandTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.spy;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -47,8 +48,7 @@ class ChatCommandTest {
     @Mock
     private OllamaChatProperties ollamaChatProperties;
     Terminal terminal;
-    @Spy
-    LineReader lineReader = LineReaderBuilder.builder().terminal(terminal).build();
+    LineReader lineReader;
 
     private StringWriter sw;
     private CommandLine cmd;
@@ -63,6 +63,7 @@ class ChatCommandTest {
     @BeforeEach
     void setUp() throws IOException {
         terminal = TerminalBuilder.terminal();
+        lineReader = spy(LineReaderBuilder.builder().terminal(terminal).build());
         sw = new StringWriter();
         var picocliCommands = picocliCommands(terminal);
         PrintWriter pw = new PrintWriter(sw);

--- a/src/test/java/org/sc/ai/cli/config/ConfigServiceTest.java
+++ b/src/test/java/org/sc/ai/cli/config/ConfigServiceTest.java
@@ -135,7 +135,7 @@ class ConfigServiceTest {
 
         @Test
         void get_withDottedKeyNotation() throws IOException {
-            // Create a test markdown file
+            // Create a YAML configuration file
             Path config = configDir.resolve("config");
             Files.writeString(config, """
                     provider: ollama
@@ -173,7 +173,7 @@ class ConfigServiceTest {
 
         @Test
         void set_mutuallyExclusiveValues() throws IOException {
-            // Create a test markdown file
+            // Create a YAML configuration file
             Path config = configDir.resolve("config");
             Files.writeString(config, """
                     provider: ollama


### PR DESCRIPTION
## Summary
- correct HTML typo in README
- parse provider options correctly in `ConfigService`
- update comments in `ConfigServiceTest`
- initialize `LineReader` after terminal setup in `ChatCommandTest`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_6872395f626c833584618528cf761f10