### PR TITLE
Add semver gradle plugin

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -354,4 +354,11 @@ Available Gradle tasks for documentation:
 ./gradlew asciidoctor           # Convert AsciiDoc to HTML
 ```
 
+## Versioning
+
+This project uses the [Semver Gradle plugin](https://github.com/JavierSegoviaCordoba/semver)
+to determine the version from Git tags. The `semver` plugin computes the
+`project.version` dynamically, so each build reflects the current tag or
+snapshot suffix.
+
 The build system automatically detects whether templates exist and uses them for enhanced output, or falls back to standard generation.

--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,21 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.5.3'
-	id 'io.spring.dependency-management' version '1.1.7'
-	id 'org.graalvm.buildtools.native' version '0.10.6'
-	id 'org.asciidoctor.jvm.convert' version '4.0.3'
-	id 'org.openrewrite.rewrite' version '7.9.0'
+        id 'java'
+        id 'org.springframework.boot' version '3.5.3'
+        id 'io.spring.dependency-management' version '1.1.7'
+        id 'org.graalvm.buildtools.native' version '0.10.6'
+        id 'org.asciidoctor.jvm.convert' version '4.0.3'
+        id 'org.openrewrite.rewrite' version '7.9.0'
+        id 'com.javiersc.semver' version '1.2.0'
 }
 
 group = 'org.sc.ai'
-version = '0.0.1-SNAPSHOT'
+version = semver.version
 description = 'sc cli - simple ai for everyday people'
+
+semver {
+    tagPrefix.set('')
+    snapshotSuffix.set('-SNAPSHOT')
+}
 
 java {
 	toolchain {


### PR DESCRIPTION
## Summary
- enable `com.javiersc.semver` Gradle plugin
- configure semver to derive version dynamically
- document versioning in README

## Testing
- `./gradlew tasks` *(fails: Unable to tunnel through proxy)*
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_687260e2b2988335b45c85ff8a65380c